### PR TITLE
set display to null while gaia-dialogs are gone.

### DIFF
--- a/src/actions/toolbar.js
+++ b/src/actions/toolbar.js
@@ -1,5 +1,6 @@
 import Debug from 'debug';
 import AppStore from '../stores/app';
+import DisplayActions from '../actions/display';
 
 
 let debug = Debug('ToolbarActions');
@@ -14,6 +15,9 @@ class ToolbarActions {
     debug('setActiveItem', arguments);
 
     AppStore.state.toolbar.activeItem = value;
+    if (value === 'none') {
+      DisplayActions.changeViews(null);
+    }
     AppStore.emitChange();
   }
 }


### PR DESCRIPTION
STR to reproduce this issue:
1. open vaani
2. open help or community dialog
3. close it
4. tap mic icon

nothing happen....
